### PR TITLE
sphinx-theme-builder 0.2.0b2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,8 @@ requirements:
     - packaging
     - pyproject-metadata
     - rich
-    - typing_extensions  # [py <= 37]
-    - tomli    # [py < 311]
+    - typing_extensions  # [py<=37]
+    - tomli    # [py<311]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,23 +11,24 @@ source:
   sha256: e9cd98c2bb35bf414fe721469a043cdcc10f0808d1ffcf606acb4a6282a6f288
 
 build:
+  skip: true  # [py<37]
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
     - flit-core 3.3.0
     - pip
-    - python >=3.7
+    - python
   run:
+    - python
     - nodeenv
     - packaging
     - pyproject-metadata
-    - python >=3.7
     - rich
     - setuptools
-    - tomli
+    - typing_extensions  # [py <= 37]
+    - tomli    # [py < 311]
 
 test:
   imports:
@@ -40,7 +41,7 @@ test:
 about:
   home: https://pypi.org/project/sphinx-theme-builder/
   summary: A tool for authoring Sphinx themes with a simple (opinionated) workflow.
-  dev_url: https://github.com/pradyunsg/sphinx_theme_builder
+  dev_url: https://github.com/pradyunsg/sphinx-theme-builder
   license: MIT
   license_file: LICENSE
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ about:
   license: MIT
   license_file: LICENSE
   license_family: MIT
-  doc_url: https://pypi.org/project/sphinx-theme-builder/
+  doc_url: https://sphinx-theme-builder.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,8 @@ requirements:
     - flit-core 3.3.0
     - pip
     - python
+    - typing_extensions  # [py <= 37]
+    - tomli    # [py < 311]
   run:
     - python
     - nodeenv
@@ -27,8 +29,6 @@ requirements:
     - pyproject-metadata
     - rich
     - setuptools
-    - typing_extensions  # [py <= 37]
-    - tomli    # [py < 311]
 
 test:
   imports:
@@ -40,10 +40,14 @@ test:
 
 about:
   home: https://pypi.org/project/sphinx-theme-builder/
+  description: |
+    Streamline the Sphinx theme development workflow, by building upon existing standardised tools.
   summary: A tool for authoring Sphinx themes with a simple (opinionated) workflow.
   dev_url: https://github.com/pradyunsg/sphinx-theme-builder
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  doc_url: https://pypi.org/project/sphinx-theme-builder/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,15 +20,14 @@ requirements:
     - flit-core 3.3.0
     - pip
     - python
-    - typing_extensions  # [py <= 37]
-    - tomli    # [py < 311]
   run:
     - python
     - nodeenv
     - packaging
     - pyproject-metadata
     - rich
-    - setuptools
+    - typing_extensions  # [py <= 37]
+    - tomli    # [py < 311]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 
 requirements:
   host:
-    - flit-core >=3.2,<4
+    - flit-core 3.3.0
     - pip
     - python
   run:
@@ -26,6 +26,7 @@ requirements:
     - packaging
     - pyproject-metadata
     - rich
+    - setuptools
     - typing_extensions  # [py<=37]
     - tomli    # [py<311]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 
 requirements:
   host:
-    - flit-core 3.3.0
+    - flit-core >=3.2,<4
     - pip
     - python
   run:


### PR DESCRIPTION
> ## ☆ Sphinx-theme-builder 0.2.0b2 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-6963) 
[Upstream](https://github.com/pradyunsg/sphinx-theme-builder/tree/main?tab=readme-ov-file)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Added skip to python versions less than 3.7
> *  Updated `about` section